### PR TITLE
Add blockable binds

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,4 +1,4 @@
-use inputbot::{KeybdKey::*, MouseButton::*, *};
+use inputbot::{BlockInput::*, KeybdKey::*, MouseButton::*, *};
 use std::{thread::sleep, time::Duration};
 
 fn main() {
@@ -27,6 +27,15 @@ fn main() {
 
     // Move mouse.
     QKey.bind(|| MouseCursor.move_rel(10, 10));
+
+    // Block the A key when left shift is held.
+    AKey.blockable_bind(|| {
+        if LShiftKey.is_pressed() {
+            Block
+        } else {
+            DontBlock
+        }
+    });
 
     // Call this to start listening for bound inputs.
     handle_input_events();

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,9 +6,15 @@ pub use std::{
     thread::spawn,
 };
 
+pub enum Bind {
+    NormalBind(BindHandler),
+    BlockableBind(BlockableBindHandler),
+}
+
 pub type BindHandler = Arc<Fn() + Send + Sync + 'static>;
-pub type KeybdBindMap = HashMap<KeybdKey, BindHandler>;
-pub type MouseBindMap = HashMap<MouseButton, BindHandler>;
+pub type BlockableBindHandler = Arc<Fn() -> BlockInput + Send + Sync + 'static>;
+pub type KeybdBindMap = HashMap<KeybdKey, Bind>;
+pub type MouseBindMap = HashMap<MouseButton, Bind>;
 
 lazy_static! {
     pub static ref KEYBD_BINDS: Mutex<KeybdBindMap> = Mutex::new(KeybdBindMap::new());

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -183,7 +183,7 @@ fn handle_input_event(event: Event) {
             let key = keyboard_key_event.key();
             if let Some(keybd_key) = scan_code_to_key(key) {
                 if keyboard_key_event.key_state() == KeyState::Pressed {
-                    if let Some(cb) = KEYBD_BINDS.lock().unwrap().get(&keybd_key) {
+                    if let Some(Bind::NormalBind(cb)) = KEYBD_BINDS.lock().unwrap().get(&keybd_key) {
                         let cb = Arc::clone(cb);
                         spawn(move || cb());
                     };
@@ -203,7 +203,7 @@ fn handle_input_event(event: Event) {
                 } {
                     if button_event.button_state() == ButtonState::Pressed {
                         BUTTON_STATES.lock().unwrap().insert(mouse_button, true);
-                        if let Some(cb) = MOUSE_BINDS.lock().unwrap().get(&mouse_button) {
+                        if let Some(Bind::NormalBind(cb)) = MOUSE_BINDS.lock().unwrap().get(&mouse_button) {
                             let cb = Arc::clone(cb);
                             spawn(move || cb());
                         };

--- a/src/public.rs
+++ b/src/public.rs
@@ -1,6 +1,12 @@
 use crate::common::*;
 use std::{thread::sleep, time::Duration};
 
+// TODO: Come up with a better name
+pub enum BlockInput {
+    Block,
+    DontBlock,
+}
+
 #[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
 pub enum KeybdKey {
     BackspaceKey,
@@ -111,7 +117,17 @@ pub struct MouseWheel;
 
 impl KeybdKey {
     pub fn bind<F: Fn() + Send + Sync + 'static>(self, callback: F) {
-        KEYBD_BINDS.lock().unwrap().insert(self, Arc::new(callback));
+        KEYBD_BINDS
+            .lock()
+            .unwrap()
+            .insert(self, Bind::NormalBind(Arc::new(callback)));
+    }
+
+    pub fn blockable_bind<F: Fn() -> BlockInput + Send + Sync + 'static>(self, callback: F) {
+        KEYBD_BINDS
+            .lock()
+            .unwrap()
+            .insert(self, Bind::BlockableBind(Arc::new(callback)));
     }
 
     pub fn unbind(self) {
@@ -121,7 +137,17 @@ impl KeybdKey {
 
 impl MouseButton {
     pub fn bind<F: Fn() + Send + Sync + 'static>(self, callback: F) {
-        MOUSE_BINDS.lock().unwrap().insert(self, Arc::new(callback));
+        MOUSE_BINDS
+            .lock()
+            .unwrap()
+            .insert(self, Bind::NormalBind(Arc::new(callback)));
+    }
+
+    pub fn blockable_bind<F: Fn() -> BlockInput + Send + Sync + 'static>(self, callback: F) {
+        MOUSE_BINDS
+            .lock()
+            .unwrap()
+            .insert(self, Bind::BlockableBind(Arc::new(callback)));
     }
 
     pub fn unbind(self) {

--- a/src/public.rs
+++ b/src/public.rs
@@ -1,7 +1,6 @@
 use crate::common::*;
 use std::{thread::sleep, time::Duration};
 
-// TODO: Come up with a better name
 pub enum BlockInput {
     Block,
     DontBlock,


### PR DESCRIPTION
I wanted to be able to make a bind conditionally block, so I came up with this. The public API looks like this:
```rust
use inputbot::{BlockInput::*, KeybdKey::*};

// Block the A key when left shift is held.
AKey.blockable_bind(|| {
    if LShiftKey.is_pressed() {
        Block
    } else {
        DontBlock
    }
});
```

To know whether or not to block an input we need to wait until the function finishes, which blocks the message loop. This could be an issue if the handler takes too long. We could warn and document this, telling people to spawn a new thread for heavy tasks. Something like this:
```rust
AKey.blockable_bind(|| {
    // Instead of doing this
    // SuperLongAndHeavyTask();
    // Do this
    thread::spawn(move || {
        SuperLongAndHeavyTask();
    });
    if LShiftKey.is_pressed() {
        Block
    } else {
        DontBlock
    }
});
```

Or we could make the `blockable_bind` function callback signature return `(BlockInput, Option<Fn() + Send + Sync + 'static>)`, which in use would look like:
```rust
AKey.blockable_bind(|| {
    if LShiftKey.is_pressed() {
        (Block, Some(SuperLongAndHeavyTask))
    } else {
        (DontBlock, Some( SuperLongAndHeavyTask))
    }
});
```

This approach adds some boilerplate if you don't want to return a function `(Block, None)`, and you would still have to spawn a new thread if you wanted some heavy tasks before the return, which I don't think is a common use case. Any advise for this would be great.

Also I couldn't come up with a great name for [this](https://github.com/ocboogie/InputBot/blob/1a0a7cde65f1eef7642f9789fb5457ed7f13cf6a/src/public.rs#L5) Enum, which is for the user to return whether or not the input should be blocked. We could also use a bool, but an Enum is more readable in my opinion.

I only implemented this for Windows, because I don't really know Mac/Linux stuff as well.