### PR TITLE
scroll "wheel" support in linux

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -89,9 +89,24 @@ impl MouseCursor {
 }
 
 impl MouseWheel {
-    pub fn scroll_ver(self, _: i32) {}
-
-    pub fn scroll_hor(self, _: i32) {}
+    pub fn scroll_ver(self, y: i32) {
+        if y < 0 {
+          MouseButton::OtherButton(4).press();
+          MouseButton::OtherButton(4).release();
+        } else {
+          MouseButton::OtherButton(5).press();
+          MouseButton::OtherButton(5).release();
+        }
+    }
+    pub fn scroll_hor(self, x: i32) {
+        if x < 0 {
+          MouseButton::OtherButton(6).press();
+          MouseButton::OtherButton(6).release();
+        } else {
+          MouseButton::OtherButton(7).press();
+          MouseButton::OtherButton(7).release();
+        }
+    }
 }
 
 pub fn handle_input_events() {


### PR DESCRIPTION
So according to my research, in linux you actually use mouse button 4 and 5 for vertical scroll, and 6 and 7 for horizontal.  I gave this a test, seems to work!  Not as nice as the windows support for vertical scrolling.  

I didn't add this to the master branch of InputBot because that doesn't work for me - an unwrap() crash.  I went back to the time of the 0.4.0 release.  