### PR TITLE
Add MouseCursor::pos and fix move_rel and mov_abs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fn main() {
     RKey.bind(|| KeySequence("Sample text").send());
 
     // Move mouse.
-    QKey.bind(|| MouseCursor.move_rel(10, 10));
+    QKey.bind(|| MouseCursor::move_rel(10, 10));
 
     // Call this to start listening for bound inputs.
     handle_input_events();

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -26,7 +26,7 @@ fn main() {
     RKey.bind(|| KeySequence("Sample text").send());
 
     // Move mouse.
-    QKey.bind(|| MouseCursor.move_rel(10, 10));
+    QKey.bind(|| MouseCursor::move_rel(10, 10));
 
     // Block the A key when left shift is held.
     AKey.blockable_bind(|| {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -106,7 +106,7 @@ impl MouseButton {
 }
 
 impl MouseCursor {
-    pub fn move_rel(self, x: i32, y: i32) {
+    pub fn move_rel(x: i32, y: i32) {
         KEYBD_DEVICE
             .lock()
             .unwrap()
@@ -123,7 +123,7 @@ impl MouseCursor {
         //});
     }
 
-    pub fn move_abs(self, x: i32, y: i32) {
+    pub fn move_abs(x: i32, y: i32) {
         //KEYBD_DEVICE.lock().unwrap().position(&Position::X, x).unwrap();
         //KEYBD_DEVICE.lock().unwrap().position(&Position::Y, y).unwrap();
         SEND_DISPLAY.with(|display| unsafe {
@@ -133,7 +133,7 @@ impl MouseCursor {
 }
 
 impl MouseWheel {
-    pub fn scroll_ver(self, y: i32) {
+    pub fn scroll_ver(y: i32) {
         if y < 0 {
           MouseButton::OtherButton(4).press();
           MouseButton::OtherButton(4).release();
@@ -142,7 +142,7 @@ impl MouseWheel {
           MouseButton::OtherButton(5).release();
         }
     }
-    pub fn scroll_hor(self, x: i32) {
+    pub fn scroll_hor(x: i32) {
         if x < 0 {
           MouseButton::OtherButton(6).press();
           MouseButton::OtherButton(6).release();

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -59,19 +59,24 @@ impl MouseButton {
 }
 
 impl MouseCursor {
+    pub fn pos(self) -> (i32, i32) {
+        unsafe {
+            let mut point = MaybeUninit::uninit();
+            GetCursorPos(point.as_mut_ptr());
+            let point = point.assume_init();
+            (point.x, point.y)
+        }
+    }
+
     pub fn move_rel(self, dx: i32, dy: i32) {
-        send_mouse_input(MOUSEEVENTF_MOVE, 0, dx, dy);
+        let (x, y) = Self.pos();
+        self.move_abs(x + dx, y + dy);
     }
 
     pub fn move_abs(self, x: i32, y: i32) {
         unsafe {
-            send_mouse_input(
-                MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE,
-                0,
-                x * 65_335 / GetSystemMetrics(78),
-                y * 65_335 / GetSystemMetrics(79),
-            )
-        };
+            SetCursorPos(x, y);
+        }
     }
 }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -59,7 +59,7 @@ impl MouseButton {
 }
 
 impl MouseCursor {
-    pub fn pos(self) -> (i32, i32) {
+    pub fn pos() -> (i32, i32) {
         unsafe {
             let mut point = MaybeUninit::uninit();
             GetCursorPos(point.as_mut_ptr());
@@ -68,12 +68,12 @@ impl MouseCursor {
         }
     }
 
-    pub fn move_rel(self, dx: i32, dy: i32) {
-        let (x, y) = Self.pos();
-        self.move_abs(x + dx, y + dy);
+    pub fn move_rel(dx: i32, dy: i32) {
+        let (x, y) = Self::pos();
+        Self::move_abs(x + dx, y + dy);
     }
 
-    pub fn move_abs(self, x: i32, y: i32) {
+    pub fn move_abs(x: i32, y: i32) {
         unsafe {
             SetCursorPos(x, y);
         }
@@ -81,11 +81,11 @@ impl MouseCursor {
 }
 
 impl MouseWheel {
-    pub fn scroll_ver(self, dwheel: i32) {
+    pub fn scroll_ver(dwheel: i32) {
         send_mouse_input(MOUSEEVENTF_WHEEL, unsafe { transmute(dwheel * 120) }, 0, 0);
     }
 
-    pub fn scroll_hor(self, dwheel: i32) {
+    pub fn scroll_hor(dwheel: i32) {
         send_mouse_input(MOUSEEVENTF_HWHEEL, unsafe { transmute(dwheel * 120) }, 0, 0);
     }
 }


### PR DESCRIPTION
As discussed in #16.

Not sure if the name is good. Maybe `get_pos` would be better?

Also, the `MouseCursor` functions taking `self` is a bit awkward. Maybe it would be better to just make them associated methods? Or at least make it `Copy`?

Edit: Also, I'm using `MaybeUninit` since I saw it used somewhere else in the code but I just realized that the other place is using `MaybeUninit::zeroed`. I think it should be safe as is and maybe even slightly better for performance (although the difference is probably minimal) but if you want I can change it. Also, maybe it would be clearer (and work in earlier Rust versions?) to use `std::mem::zeroed()`?

Edit2: Closes #16 