### PR TITLE
[NF] add block_bind for windows

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -9,10 +9,12 @@ use once_cell::sync::Lazy;
 
 pub enum Bind {
     NormalBind(BindHandler),
+    BlockBind(BlockBindHandler),
     BlockableBind(BlockableBindHandler),
 }
 
 pub type BindHandler = Arc<dyn Fn() + Send + Sync + 'static>;
+pub type BlockBindHandler = Arc<dync Fn() + Send + Sync + 'static>;
 pub type BlockableBindHandler = Arc<dyn Fn() -> BlockInput + Send + Sync + 'static>;
 pub type KeybdBindMap = HashMap<KeybdKey, Bind>;
 pub type MouseBindMap = HashMap<MouseButton, Bind>;

--- a/src/public.rs
+++ b/src/public.rs
@@ -122,6 +122,13 @@ impl KeybdKey {
             .insert(self, Bind::NormalBind(Arc::new(callback)));
     }
 
+    pub fn block_bind<F: Fn() + Send + Sync + 'static>(self, callback: F) {
+        KEYBD_BINDS
+            .lock()
+            .unwrap()
+            .insert(self, Bind::BlockBind(Arc::new(callback)));
+    }
+
     pub fn blockable_bind<F: Fn() -> BlockInput + Send + Sync + 'static>(self, callback: F) {
         KEYBD_BINDS
             .lock()
@@ -140,6 +147,13 @@ impl MouseButton {
             .lock()
             .unwrap()
             .insert(self, Bind::NormalBind(Arc::new(callback)));
+    }
+
+    pub fn block_bind<F: Fn() + Send + Sync + 'static>(self, callback: F) {
+        KEYBD_BINDS
+            .lock()
+            .unwrap()
+            .insert(self, Bind::BlockBind(Arc::new(callback)));
     }
 
     pub fn blockable_bind<F: Fn() -> BlockInput + Send + Sync + 'static>(self, callback: F) {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -117,6 +117,11 @@ unsafe extern "system" fn keybd_proc(code: c_int, w_param: WPARAM, l_param: LPAR
                     let cb = Arc::clone(cb);
                     spawn(move || cb());
                 }
+                Bind::BlockBind(cb) => {
+                    let cb = Arc::clone(cb);
+                    spawn(move || cb());
+                    return 1;
+                }
                 Bind::BlockableBind(cb) => {
                     if let BlockInput::Block = cb() {
                         return 1;
@@ -151,6 +156,11 @@ unsafe extern "system" fn mouse_proc(code: c_int, w_param: WPARAM, l_param: LPAR
                 Bind::NormalBind(cb) => {
                     let cb = Arc::clone(cb);
                     spawn(move || cb());
+                }
+                Bind::BlockBind(cb) => {
+                    let cb = Arc::clone(cb);
+                    spawn(move || cb());
+                    return 1;
                 }
                 Bind::BlockableBind(cb) => {
                     if let BlockInput::Block = cb() {


### PR DESCRIPTION
## Summary
block original key and replace with another
```rust
use inputbot::{KeybdKey::*, *};

fn main() {
    // Block the A key when left shift is held.
    CapsLockKey.block_bind(|| {
        if AKey.is_pressed() {
            // replace with ctrl+a
        } else {
            // replace with esc
        }
    });

    // Call this to start listening for bound inputs.
    handle_input_events();
}
```