### PR TITLE
Added support to check if ScrollLock is toggled.

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -2,6 +2,7 @@ use inputbot::{BlockInput::*, KeybdKey::*, MouseButton::*, *};
 use std::{thread::sleep, time::Duration};
 
 fn main() {
+
     // Autorun for videogames.
     NumLockKey.bind(|| {
         while NumLockKey.is_toggled() {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -75,6 +75,7 @@ impl KeybdKey {
 
     pub fn is_toggled(self) -> bool {
         if let Some(key) = match self {
+            KeybdKey::ScrollLockKey => Some(4),
             KeybdKey::NumLockKey => Some(2),
             KeybdKey::CapsLockKey => Some(1),
             _ => None,


### PR DESCRIPTION
Can now check if scroll lock is toggled in Linux.
```rust
ScrollLockKey.is_toggled()
```