### PR TITLE
Updated public.rs to expose get_keybd_key publicly

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -168,7 +168,7 @@ impl MouseButton {
     }
 }
 
-fn get_keybd_key(c: char) -> Option<KeybdKey> {
+pub fn get_keybd_key(c: char) -> Option<KeybdKey> {
     match c {
         ' ' => Some(KeybdKey::SpaceKey),
         'A' | 'a' => Some(KeybdKey::AKey),


### PR DESCRIPTION
Fort my use I need to bind multiple keys by iterating over multiple characters. Since the Keybdkey enum doesn't support IntoIterator, I'd like to iterate over chars of a string and bind each one. For that, I need get_keybd_key. Not sure why it's not public to begin with