### PR TITLE
Synchronized device after use. Added init_device

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -67,25 +67,36 @@ static FAKE_DEVICE: Lazy<Mutex<uinput::Device>> = Lazy::new(|| {
 });
 
 
+/// Requests the fake device to be generated.
+/// 
+/// Can be called before using the fake device to prevent it from 
+/// building when you first try to use it.
+pub fn init_device() {
+    FAKE_DEVICE.lock().unwrap();
+}
+
+
 impl KeybdKey {
     pub fn is_pressed(self) -> bool {
         *KEY_STATES.lock().unwrap().entry(self).or_insert(false)
     }
 
     pub fn press(self) {
-        FAKE_DEVICE
-            .lock()
-            .unwrap()
+        let mut device = FAKE_DEVICE.lock().unwrap();
+
+        device
             .write(0x01, key_to_scan_code(self), 1)
             .unwrap();
+        device.synchronize().unwrap();
     }
 
     pub fn release(self) {
-        FAKE_DEVICE
-            .lock()
-            .unwrap()
+        let mut device = FAKE_DEVICE.lock().unwrap();
+
+        device
             .write(0x01, key_to_scan_code(self), 0)
             .unwrap();
+        device.synchronize().unwrap();
     }
 
     pub fn is_toggled(self) -> bool {


### PR DESCRIPTION
I am a big fan of your crate for device input being super simple to use and compatible with Wayland as well, thanks for making this!

When using this crate some input events I sent were not in effect immediately when I called functions like `KeybdKey::F7::press()`, but would effectively queue up several events and apply them all at once later on. Adding the `device.synchronize()` call has prevented this.

It would also sometimes not apply the first event I sent, I believe this may have been due to the device being constructed lazily. That was resolved by accessing and constructing the device through `init_device()` before sending any events.