### PR TITLE
Make callback of KeybdKey::bind_all Clone instead of Copy

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -154,8 +154,9 @@ impl KeybdKey {
             .insert(self, Bind::BlockableBind(Arc::new(callback)));
     }
 
-    pub fn bind_all<F: Fn(KeybdKey) + Send + Sync + Copy + 'static>(callback: F) {
+    pub fn bind_all<F: Fn(KeybdKey) + Send + Sync + Clone + 'static>(callback: F) {
         for key in KeybdKey::iter() {
+            let callback = callback.clone();
             let fire = move || {
                 callback(key);
             };


### PR DESCRIPTION
Motivated by [an StackOverflow question](https://stackoverflow.com/q/72419314/12122460) that tries to use a non-`Copy` closure as parameter to `KeybdKey::bind_all`. A minimal example is like this:

```rust
use std::sync::{Arc, Mutex};

use inputbot::KeybdKey;

fn main() {
    let chars = Arc::new(Mutex::new(vec![]));

    KeybdKey::bind_all(move |event| {
        if let Some(c) = inputbot::from_keybd_key(event) {
            let mut chars = chars.lock().unwrap();
            chars.push(c);
        }
    });

    inputbot::handle_input_events();
}
```

Since the closure moves `chars`, which is `Clone` but not `Copy`, the closure is not `Copy` and thus cannot be used. This PR relaxes this restriction by changing the trait bound `Copy` to `Clone` to make this possible.