### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -70,12 +70,12 @@ impl MouseButton {
 
 impl MouseCursor {
     pub fn pos() -> (i32, i32) {
-        unsafe {
+        
             let mut point = MaybeUninit::uninit();
-            GetCursorPos(point.as_mut_ptr());
-            let point = point.assume_init();
+            unsafe { GetCursorPos(point.as_mut_ptr()) };
+            let point = unsafe { point.assume_init() };
             (point.x, point.y)
-        }
+        
     }
 
     /// Moves the mouse relative to its current position by a given amount of pixels.


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html