### PR TITLE
Fixed the handling of Alt keys.

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -120,7 +120,7 @@ pub fn handle_input_events() {
 unsafe extern "system" fn keybd_proc(code: c_int, w_param: WPARAM, l_param: LPARAM) -> LRESULT {
     if KEYBD_BINDS.lock().unwrap().is_empty() {
         unset_hook(&*KEYBD_HHOOK);
-    } else if w_param as u32 == WM_KEYDOWN {
+    } else if w_param as u32 == WM_KEYDOWN || w_param as u32 == WM_SYSKEYDOWN {
         if let Some(bind) = KEYBD_BINDS
             .lock()
             .unwrap()


### PR DESCRIPTION
Most keys generate a WM_KEYDOWN(0x0100) event, but the Alt keys generate a WM_SYSKEYDOWN(0x0104) event. So we need to listen for the WM_SYSKEYDOWN event too.