### PR TITLE
Use windows crate rather than winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ strum_macros = "0.25.2"
 once_cell = "1.9.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["winuser"] }
+windows = { version = "0.51.1", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_UI_Input_KeyboardAndMouse"] }
 
 [target.'cfg(target_os="linux")'.dependencies]
 libc = "0.2.113"


### PR DESCRIPTION
The `winapi` crate has not been updated since 2018, and while I don't think it is necessarily broken, or bad in any noticeable way, the `windows` crate receives constant updates and is maintained by Microsoft themselves, which generally means it's more likely to be supported in future, especially if security issues do arise.

TLDR; The `winapi` crate is old and unmaintained, and probably should not be used, unless it has to be.

Note, I have not had a chance to test these changes yet, so some things may be broken.