### PR TITLE
Fix linux build issues, and immediately drop FAKE_DEVICE lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ windows = { version = "0.51.1", features = [
 [target.'cfg(target_os="linux")'.dependencies]
 libc = "0.2.148"
 input = "0.8.3"
-nix = "0.27.1"
+nix = { version = "0.27.1", features = ["fs"] }
 x11 = { version = "2.21.0", features = ["xlib", "xtest"] }
 uinput = { version = "0.1.3", default-features = false }


### PR DESCRIPTION
- Fixed build issues on Linux that were preventing the library from compiling
- Fixed a clippy warning in `init_device`, which warned about the FAKE_DEVICE mutex lock being immediately dropped. Given this is intentional, wrapping it in an explicit drop statement silences the issue.
- Also vscode did some formatting automatically