### PR TITLE
Allow windows event loop to end in the same manner as linux

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -21,7 +21,7 @@ use windows::Win32::{
             CallNextHookEx, GetCursorPos, GetMessageW, SetCursorPos, SetWindowsHookExW,
             UnhookWindowsHookEx, HHOOK, KBDLLHOOKSTRUCT, MSG, MSLLHOOKSTRUCT, WH_KEYBOARD_LL,
             WH_MOUSE_LL, WINDOWS_HOOK_ID, WM_KEYDOWN, WM_LBUTTONDOWN, WM_MBUTTONDOWN,
-            WM_RBUTTONDOWN, WM_SYSKEYDOWN, WM_XBUTTONDOWN, XBUTTON1, XBUTTON2,
+            WM_RBUTTONDOWN, WM_SYSKEYDOWN, WM_XBUTTONDOWN, XBUTTON1, XBUTTON2, SetTimer, KillTimer,
         },
     },
 };
@@ -126,8 +126,15 @@ pub fn handle_input_events() {
     if !KEYBD_BINDS.lock().unwrap().is_empty() {
         set_hook(WH_KEYBOARD_LL, &KEYBD_HHOOK, keybd_proc);
     };
-    let mut msg: MSG = unsafe { MaybeUninit::zeroed().assume_init() };
-    unsafe { GetMessageW(&mut msg, None, 0, 0) };
+
+    let timer_id = unsafe { SetTimer(None, 0, 100, None) };
+
+    while !MOUSE_BINDS.lock().unwrap().is_empty() || !KEYBD_BINDS.lock().unwrap().is_empty() {
+        let mut msg: MSG = unsafe { MaybeUninit::zeroed().assume_init() };
+        unsafe { GetMessageW(&mut msg, None, 0, 0) };
+    }
+
+    let _ = unsafe { KillTimer(None, timer_id) };
 }
 
 unsafe extern "system" fn keybd_proc(code: c_int, w_param: WPARAM, l_param: LPARAM) -> LRESULT {


### PR DESCRIPTION
This PR addresses an inability to softly exit the blocking windows messaging call `GetMessageW` by routinely prodding the message pump with timer messages. I've also attempted to homogenise exit behaviour across supported platforms - the linux platform appears end the loop when there are no more key/mouse binds, so I have implemented the same logic here.

### Changes
* Created a windows timer object to routinely post `WM_TIMER` to the same thread as `GetMessageW` - this causes `GetMessageW` to exit naturally
* Put `GetMessageW` into a loop, testing for the presence of `MOUSE_BINDS` and `KEBD_BINDS` before exiting - similar to how linux platform appears to work

### Potential Alternative Solution
Actually a timer and loop may not be necessary - all that needs to be done is sending some kind of windows message on the thread that calls `GetMessageW`. In practice, I've found that the `SendMessage` functions require a valid `HWND` and can't be sent globally. If there is a way to send a message on the thread without a valid `HWND`, then that could be used to exit `GetMessageW` instead.

However, the timer and loop does allow us to make the exit behaviour very similar for both platforms, so swings and roundabouts.

### Extra Info
Motivation and insight for this came from: https://stackoverflow.com/questions/65571185/getmessagew-is-blocking-the-calling-thread-receiving-no-messages