### PR TITLE
Enable `stop_handling_input_events` on both platforms and make auto stop optional

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -546,3 +546,8 @@ impl KeySequence<'_> {
         }
     }
 }
+
+/// Stops `handle_input_events()` (threadsafe)
+pub fn stop_handling_input_events() {
+    HANDLE_EVENTS.store(false, Ordering::Relaxed);
+}

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -118,8 +118,8 @@ impl MouseWheel {
     }
 }
 
-/// Starts listening for bound input events.
-pub fn handle_input_events() {
+/// Starts listening for bound input events (otionally stopping when binds are removed).
+pub fn handle_input_events(auto_stop: bool) {
     if !MOUSE_BINDS.lock().unwrap().is_empty() {
         set_hook(WH_MOUSE_LL, &MOUSE_HHOOK, mouse_proc);
     };
@@ -129,7 +129,8 @@ pub fn handle_input_events() {
 
     let timer_id = unsafe { SetTimer(None, 0, 100, None) };
 
-    while !MOUSE_BINDS.lock().unwrap().is_empty() || !KEYBD_BINDS.lock().unwrap().is_empty() {
+    HANDLE_EVENTS.store(true, Ordering::Relaxed);
+    while should_continue(auto_stop) {
         let mut msg: MSG = unsafe { MaybeUninit::zeroed().assume_init() };
         unsafe { GetMessageW(&mut msg, None, 0, 0) };
     }


### PR DESCRIPTION
This PR builds upon #90, further enhancing exit comprehension by giving the user the option to choose between auto stopping when no binds are present (the old windows/linux behaviour) and stopping only upon explicit call to `stop_handling_input_events` (previously a linux only feature). The `stop_handling_input_events` function is now available to both platforms.

**Warning !!!** Only compiled and tested on windows.

# Migration Guide
* `handle_input_events` now expects an `auto_stop` boolean (where `true` is the old exit behaviour and `false` requires an explicit call to `stop_handling_input_events` to exit)

# Motivation
I should mention the main motivation for this.

The obvious motivation is to make `stop_handling_input_events` available across platforms.

But secondly, I'm working on an app which may at some point have zero binds present. I don't want the input handler to exit every time the user removes binds. Therefore, I added the option to set `auto_stop` behaviour.

Now that I think on it, perhaps I should split this PR into two... Thoughts?

# Changes
* Moved `stop_handling_input_events` to `public.rs`
* Added `should_continue(auto_stop)` function to `common.rs` to ensure loop behaviour is identical
* Loop behaviour when `auto_stop` is `true` is: `HANDLE_EVENTS && have_any_binds_present`
* Loop behaviour when `auto_stop` is `false` is just: `HANDLE_EVENTS`
* `handle_input_events` now takes a boolean `auto_stop` parameter, which is internally passed to `should_continue` to drive the input loop
* Moved `HANDLE_EVENTS` atomic to `common.rs`
* `HANDLE_EVENTS` now defaults to `false` and each `handle_input_events` function now sets it to true just before the loop starts - this is because the previous arrangement would cause the `handle_input_events` function to immediately exit if it follows a call to `stop_handling_input_events`, which would be surprising behaviour to most users
