### PR TITLE
MouseButton::{MousewheelDown,MousewheelUp}

### DIFF
--- a/examples/blockable_binds.rs
+++ b/examples/blockable_binds.rs
@@ -1,5 +1,9 @@
-use inputbot::{BlockInput::*, KeybdKey::*};
-
+use inputbot::{
+    BlockInput::*,
+    KeybdKey::*,
+    MouseButton::{LeftButton, MousewheelDown},
+};
+use std::thread;
 // This example demonstrates blocking input with conditional flags, such as another key being
 // pressed or toggled. This example currently does not work on Linux.
 
@@ -17,6 +21,27 @@ fn main() {
 
     // Block the K key when left shift is held.
     KKey.block_bind(|| ());
+
+    MousewheelDown.blockable_bind(|| {
+        if LControlKey.is_pressed() {
+            // Unlike block_bind and bind, blockable_bind runs the callback synchronously,
+            // on the hooking thread.
+            // This can cause performance issues one some operating systems, particularly Windows 11.
+            // A solution is to spawn the work part of the callback onto a new thread
+            // and synchronously return the BlockInput.
+
+            // DANGER: Don't Send mouse input on the mouse hook thread!
+            // LeftButton.press(); LeftButton.release();
+            thread::spawn(|| {
+                // Safe: executing on another thread.
+                LeftButton.press();
+                LeftButton.release();
+                println!("Mousewheel Down")
+            });
+            return Block;
+        }
+        DontBlock
+    });
 
     // Call this to start listening for bound inputs.
     inputbot::handle_input_events();

--- a/src/linux/inputs.rs
+++ b/src/linux/inputs.rs
@@ -475,6 +475,8 @@ impl From<MouseButton> for uinput::event::controller::Mouse {
             MouseButton::LeftButton => Mouse::Left,
             MouseButton::RightButton => Mouse::Right,
             MouseButton::MiddleButton => Mouse::Middle,
+            MouseButton::MousewheelDown => unimplemented!(),
+            MouseButton::MousewheelUp => unimplemented!(),
             MouseButton::X1Button => unimplemented!(),
             MouseButton::X2Button => unimplemented!(),
             MouseButton::OtherButton(_) => unimplemented!(),

--- a/src/public.rs
+++ b/src/public.rs
@@ -144,7 +144,8 @@ pub enum MouseButton {
     RightButton,
     X1Button,
     X2Button,
-
+    MousewheelUp,
+    MousewheelDown,
     #[strum(disabled)]
     OtherButton(u32),
 }
@@ -390,6 +391,8 @@ impl std::fmt::Display for MouseButton {
                 MouseButton::X1Button => "Mouse Backward",
                 MouseButton::X2Button => "Mouse Forward",
                 MouseButton::OtherButton(code) => return write!(f, "{code} Click"),
+                MouseButton::MousewheelDown => "Mousewheel Down",
+                MouseButton::MousewheelUp => "Mousewheel Up"
             }
         )
     }

--- a/src/windows/inputs.rs
+++ b/src/windows/inputs.rs
@@ -263,6 +263,8 @@ impl From<MouseButton> for u32 {
             MiddleButton => 0x04,
             X1Button => 0x05,
             X2Button => 0x06,
+            MousewheelDown => 0x07,
+            MousewheelUp => 0x08,
             OtherButton(code) => code,
         }
     }


### PR DESCRIPTION
Introduce two new enumerators for MouseButton: MouseButton::MousewheelDown and MouseButton::MousewheelUp.

These events fire on each "notch" of a mousewheel advance. I dug out a mouse with a smooth wheel too, and winapi still only sends either 120 or -120 in the highword of hook, corresponding to one "notch", even on a smooth wheel.

Patch implements Windows only.