### PR TITLE
serde feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Many missing keys
 - Check if ScrollLock is toggled
 - `bind_all`
+- MousewheelUp and MousewheelDown
+- "serde" feature
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0
+
+### Added
+
+- `serde` feature
+
 ## 0.6.0
 
 ### Added
@@ -7,8 +13,8 @@
 - Many missing keys
 - Check if ScrollLock is toggled
 - `bind_all`
-- MousewheelUp and MousewheelDown
-- "serde" feature
+- `MousewheelUp` and `MousewheelDown`
+- `KeybdKey::is_bound` and `MouseButton::is_bound`
 
 ## Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ uinput = { version = "0.1.3", default-features = false }
 toml = { version = "^0.8" }
 
 [features]
-default = ["serde"]
 serde = ["dep:serde", "dep:regex", "dep:thiserror"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ edition = "2021"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.2"
 once_cell = "1.18.0"
+lazy_static = { version = "^1.4", optional = true }
+thiserror = { version = "^1.0", optional = true }
+regex = { version = "^1.0", optional = true }
+serde = { version = "^1.0", optional = true,  features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.51.1", features = [
@@ -30,3 +34,13 @@ input = "0.8.3"
 nix = { version = "0.27.1", features = ["fs"] }
 x11 = { version = "2.21.0", features = ["xlib", "xtest"] }
 uinput = { version = "0.1.3", default-features = false }
+
+[dev-dependencies]
+toml = { version = "^0.8" }
+
+[features]
+serde = ["dep:serde", "dep:regex", "dep:thiserror", "dep:lazy_static"]
+
+[[example]]
+name = "serde"
+required-features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.2"
 once_cell = "1.18.0"
-lazy_static = { version = "^1.4", optional = true }
 thiserror = { version = "^1.0", optional = true }
 regex = { version = "^1.0", optional = true }
 serde = { version = "^1.0", optional = true,  features = ["derive"] }
@@ -39,7 +38,8 @@ uinput = { version = "0.1.3", default-features = false }
 toml = { version = "^0.8" }
 
 [features]
-serde = ["dep:serde", "dep:regex", "dep:thiserror", "dep:lazy_static"]
+default = ["serde"]
+serde = ["dep:serde", "dep:regex", "dep:thiserror"]
 
 [[example]]
 name = "serde"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fn main() {
     });
 
     // Call this to start listening for bound inputs.
-    inputbot::handle_input_events();
+    inputbot::handle_input_events(false);
 }
 ```
 

--- a/examples/autoclicker.rs
+++ b/examples/autoclicker.rs
@@ -28,5 +28,5 @@ fn main() {
     });
 
     // Call this to start listening for bound inputs.
-    inputbot::handle_input_events();
+    inputbot::handle_input_events(false);
 }

--- a/examples/bind_all.rs
+++ b/examples/bind_all.rs
@@ -18,5 +18,5 @@ fn main() {
     });
 
     // Call this to start listening for bound inputs.
-    inputbot::handle_input_events();
+    inputbot::handle_input_events(false);
 }

--- a/examples/blockable_binds.rs
+++ b/examples/blockable_binds.rs
@@ -44,5 +44,5 @@ fn main() {
     });
 
     // Call this to start listening for bound inputs.
-    inputbot::handle_input_events();
+    inputbot::handle_input_events(false);
 }

--- a/examples/key_sequences.rs
+++ b/examples/key_sequences.rs
@@ -19,5 +19,5 @@ fn main() {
     });
 
     // Call this to start listening for bound inputs.
-    inputbot::handle_input_events();
+    inputbot::handle_input_events(false);
 }

--- a/examples/move_mouse.rs
+++ b/examples/move_mouse.rs
@@ -26,5 +26,5 @@ fn main() {
     });
 
     // Call this to start listening for bound inputs.
-    inputbot::handle_input_events();
+    inputbot::handle_input_events(false);
 }

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -31,6 +31,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Call this to start listening for bound inputs.
-    inputbot::handle_input_events();
+    inputbot::handle_input_events(false);
     Ok(())
 }

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,0 +1,36 @@
+use inputbot::{KeySequence, KeybdKey};
+use serde::Deserialize;
+use toml;
+/// This example demonstrates sending sequences of key presses / characters via a KeySequence.
+/// This can be used, for example, to create a macro which types a specific string.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // If you are on Linux, you may wish to call this function first to avoid a startup delay when
+    // the fake device is created. Otherwise, your first input event - if it is a key sequence - may
+    // have missing characters.
+    //     inputbot::init_device();
+
+    // With the serde feature, KeybdKey and MouseButton are Deserialize, so structs
+    // that include these types can derive Deserialize. 
+    #[derive(Deserialize)]
+    struct Config {
+        hello: KeybdKey,
+        world: KeybdKey
+    }
+
+    let config : Config = toml::from_str(r#"
+    hello = "numpad1"
+    world = "numpad2"
+    "#)?;
+
+    config.hello.block_bind(|| {
+        KeySequence("Hello,").send();
+    });
+    config.world.block_bind(|| {
+        KeySequence(" World!").send()
+    });
+
+    // Call this to start listening for bound inputs.
+    inputbot::handle_input_events();
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![feature(error_generic_member_access)]
 
 mod common;
 
@@ -14,3 +15,4 @@ pub use crate::windows::*;
 mod linux;
 #[cfg(target_os = "linux")]
 pub use crate::linux::*;
+

--- a/src/public.rs
+++ b/src/public.rs
@@ -420,6 +420,13 @@ impl std::str::FromStr for KeybdKey {
         if let Some(k) = KEYBOARD_CANONICAL_NAMES_LOWER.get(&s_lower) {
             return Ok(*k);
         }
+        match s_lower.as_str() {
+            "leftwindows" => { return Ok(KeybdKey::LSuper)},
+            "leftcommand" => { return Ok(KeybdKey::LSuper)},
+            "rightwindows" => { return Ok(KeybdKey::RSuper)},
+            "rightcommand" => { return Ok(KeybdKey::RSuper)},
+            _ => {}
+        }
         if let Some(caps) = OTHER_KEY.captures(s) {
             let v = &caps[1]
                 .parse::<u64>()


### PR DESCRIPTION
When using inputbot to expose global hotkeys for users, it's natural to allow the user to configure the keybinds via a configuration file. In order to do this, it's necessary to define a serialization format for KeybdKey and MouseButton, and that format should be convenient for humans to read and write.

I needed this for an app I'm writing, and I think it'd be good for the library (and for me) to upstream serialization.

However, serialization is a user-facing change, and there were several judgment calls to make. The foremost question was whether to preserve the existing Display impls and define a different "canonical" mapping for the serialization format. While I tried it both ways, ultimately I felt it'd be confusing if Display didn't roundtrip through serialization, and conversely, that it'd be strange if the serialization format required two words to represent a key. So I changed some of the Display impls, e.g. "Left Control" became "LeftControl".

The second issue is that deserialization requires exposing an error type. It might make sense for inputbot to expose an omnibus error enum, but I chose to keep it contained to just a deserialization error type in this patch. I generally don't like omnibus errors (e.g. `InputBot::Error`), because not every operation that can fail can fail in the same ways.

The final issue was that this patch adds a lot of dependencies to InputBot, which is a nice, lean crate. To this end, every single line of code in this patch except `#![feature(error_generic_member_access)]` in lib.rs is behind the "serde" feature gate. So, the only new deps are opt-in.

