### PR TITLE
implement released keys for windows

### DIFF
--- a/examples/bind_all.rs
+++ b/examples/bind_all.rs
@@ -12,9 +12,22 @@ fn main() {
         };
     });
 
+    // Bind all release keys to a common callback event (Windows only).
+    KeybdKey::bind_all_release(|event| {
+        match inputbot::from_keybd_key(event) {
+            Some(c) => println!("released {c}"),
+            None => println!("Unregistered Key"),
+        };
+    });
+
     // Bind all mouse buttons to a common callback event.
     MouseButton::bind_all(|event| {
         println!("{:?}", event);
+    });
+
+    // Bind all release mouse buttons to a common callback event (Windows only).
+    MouseButton::bind_all_release(|event| {
+        println!("released {:?}", event);
     });
 
     // Call this to start listening for bound inputs.

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -11,24 +11,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     inputbot::init_device();
 
     // With the serde feature, KeybdKey and MouseButton are Deserialize, so structs
-    // that include these types can derive Deserialize. 
+    // that include these types can derive Deserialize.
     #[derive(Deserialize)]
     struct Config {
         hello: KeybdKey,
-        world: KeybdKey
+        world: KeybdKey,
     }
 
-    let config : Config = toml::from_str(r#"
+    let config: Config = toml::from_str(
+        r#"
     hello = "numpad1"
     world = "numpad2"
-    "#)?;
+    "#,
+    )?;
 
     config.hello.block_bind(|| {
         KeySequence("Hello,").send();
     });
-    config.world.block_bind(|| {
-        KeySequence(" World!").send()
-    });
+    config.world.block_bind(|| KeySequence(" World!").send());
 
     // Call this to start listening for bound inputs.
     inputbot::handle_input_events(false);

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,6 +9,8 @@ pub use std::{
 
 pub enum Bind {
     Normal(Handler),
+    #[cfg(target_os = "windows")]
+    Release(Handler),
     Block(BlockHandler),
     Blockable(BlockableHandler),
 }
@@ -21,11 +23,17 @@ pub type MouseBindMap = HashMap<MouseButton, Bind>;
 
 pub static HANDLE_EVENTS: AtomicBool = AtomicBool::new(false);
 pub static KEYBD_BINDS: Lazy<Mutex<KeybdBindMap>> = Lazy::new(|| Mutex::new(KeybdBindMap::new()));
+pub static KEYBD_RELEASE_BINDS: Lazy<Mutex<KeybdBindMap>> =
+    Lazy::new(|| Mutex::new(KeybdBindMap::new()));
 pub static MOUSE_BINDS: Lazy<Mutex<MouseBindMap>> = Lazy::new(|| Mutex::new(MouseBindMap::new()));
+pub static MOUSE_RELEASE_BINDS: Lazy<Mutex<MouseBindMap>> =
+    Lazy::new(|| Mutex::new(MouseBindMap::new()));
 
 pub fn should_continue(auto_stop: bool) -> bool {
     HANDLE_EVENTS.load(Ordering::Relaxed)
         && (!auto_stop
             || !MOUSE_BINDS.lock().unwrap().is_empty()
-            || !KEYBD_BINDS.lock().unwrap().is_empty())
+            || !KEYBD_BINDS.lock().unwrap().is_empty()
+            || !KEYBD_RELEASE_BINDS.lock().unwrap().is_empty()
+            || !MOUSE_RELEASE_BINDS.lock().unwrap().is_empty())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,3 @@ pub use crate::windows::*;
 mod linux;
 #[cfg(target_os = "linux")]
 pub use crate::linux::*;
-


### PR DESCRIPTION
My attempt to solve #97 
Implements handling of KeyUp events for Windows.
Cargo fmt formatted a few lines unrelated to the PR, I also refactored the identification of mouse events to simplify implementing their release.

I don't know much about the project (1st time contributing) so if any changes are needed just let me know!