### PR TITLE
Fix nonexhaustive match in linux

### DIFF
--- a/src/linux/inputs.rs
+++ b/src/linux/inputs.rs
@@ -279,6 +279,7 @@ impl From<MouseButton> for u32 {
             X1Button => 4,
             X2Button => 5,
             OtherButton(keycode) => keycode,
+            _ => unimplemented!()
         }
     }
 }


### PR DESCRIPTION
I briefly looked for the correct keycodes for MousewheelUp and Down, but couldn't find a canonical source that also matched the same keycode values for the existing entries. I don't have a Linux deployment to test on, so didn't feel comfortable guessing.

I think this is enough to get it compiling.