### PR TITLE
Remove error_generic_member_access feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![feature(error_generic_member_access)]
 
 mod common;
 


### PR DESCRIPTION
When trying to build on stable rust, I get a complaint that the error_generic_member_access feature is only allowed on nightly.

The library doesn't appear to use this feature anyway, so it seems safe to just remove the feature gate. I can then build and use the library on stable rust.